### PR TITLE
Increase size of groupslist col

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -13,7 +13,7 @@
         <FIELD NAME="enrol_method" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="enrolment method"/>
         <FIELD NAME="profile_field" TYPE="int" LENGTH="3" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="profil field"/>
         <FIELD NAME="use_groupslist" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="use specific(s) group(s) only"/>
-        <FIELD NAME="groupslist" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Groups to use"/>
+        <FIELD NAME="groupslist" TYPE="char" LENGTH="2048" NOTNULL="false" SEQUENCE="false" COMMENT="Groups to use"/>
         <FIELD NAME="balises" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" COMMENT="Balises for letters"/>
 
       </FIELDS>


### PR DESCRIPTION
With the default column size, courses with a large number of groups can see a DB error due to exceeding the 255 character limit. This Increases the size of groupslist column to allow for large numbers of groups to be included in the auto-enrol.

Note that since this file only runs on install, this will not affect existing tables, which would need to be manually altered in order to increase the size.